### PR TITLE
Unify failure diagnostics, document architecture, automate dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,12 @@
 # the same required checks as any other change; nothing is merged automatically.
 version: 2
 updates:
-  # Development tooling only. bunpm ships zero runtime dependencies, so a
-  # production dependency appearing here should be reviewed by a human, not
-  # quietly kept up to date.
+  # Every dependency in package.json is a development dependency: bunpm ships
+  # zero runtime dependencies. That invariant is enforced by review, not here,
+  # because Dependabot's `allow: dependency-type: development` filter is not
+  # supported for the bun ecosystem (only bundler, composer, mix, maven, npm,
+  # pip and uv). A production dependency ever appearing in a Dependabot pull
+  # request is therefore a signal to question the dependency, not the config.
   #
   # The `bun` ecosystem, not `npm`, is what keeps package.json and the committed
   # text bun.lock in step. CI installs with `bun install --frozen-lockfile`, so a
@@ -15,8 +18,6 @@ updates:
       interval: weekly
       day: monday
       timezone: Etc/UTC
-    allow:
-      - dependency-type: development
     commit-message:
       prefix: chore
       include: scope

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Weekly version updates. Dependabot opens ordinary pull requests that must pass
+# the same required checks as any other change; nothing is merged automatically.
+version: 2
+updates:
+  # Development tooling only. bunpm ships zero runtime dependencies, so a
+  # production dependency appearing here should be reviewed by a human, not
+  # quietly kept up to date.
+  #
+  # The `bun` ecosystem, not `npm`, is what keeps package.json and the committed
+  # text bun.lock in step. CI installs with `bun install --frozen-lockfile`, so a
+  # manifest bump without a matching lockfile update would fail every job.
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      timezone: Etc/UTC
+    allow:
+      - dependency-type: development
+    commit-message:
+      prefix: chore
+      include: scope
+
+  # Actions are pinned to major tags in .github/workflows/ci.yml.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      timezone: Etc/UTC
+    commit-message:
+      prefix: ci
+      include: scope

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 - Report every bunpm failure on stderr as `bunpm: <component>: <message>`,
   replacing the previous mix of `bunpm error:`, `Bootstrap error:` and unprefixed
-  installer messages. Exit codes and underlying cause text are unchanged. Scripts
-  matching the old prefixes need updating.
+  installer messages. Missing installer prerequisites are now reported by bunpm
+  instead of by the shell, and the missing-manager and prerequisite texts were
+  reworded to name the tool to install. Exit codes, signal handling and child
+  output are unchanged. Scripts matching the old prefixes or texts need updating.
 - Avoid missing-profile diagnostics on fresh Unix installs while retaining PATH
   idempotence. Preserve raw Windows User PATH references and registry value type.
 - Permit quoted batch executable paths containing parentheses and literal wildcard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Report every bunpm failure on stderr as `bunpm: <component>: <message>`,
+  replacing the previous mix of `bunpm error:`, `Bootstrap error:` and unprefixed
+  installer messages. Exit codes and underlying cause text are unchanged. Scripts
+  matching the old prefixes need updating.
 - Avoid missing-profile diagnostics on fresh Unix installs while retaining PATH
   idempotence. Preserve raw Windows User PATH references and registry value type.
 - Permit quoted batch executable paths containing parentheses and literal wildcard

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,18 @@ does not prove execution on that OS. Keep behavior fixes and regression tests in
 the same commit. Do not change global PATH, package-manager installs, or real shell
 profiles in a test. Formatting-only work belongs in a separate commit.
 
+## Diagnostics
+
+bunpm's own failures go to stderr as `bunpm: <component>: <actionable message>`,
+where the component is the failing part (`wrapper`, `exec`, `detector`,
+`bootstrap`, `install`, `uninstall`). `core/wrapper.js` has a local `diagnose`
+helper; `bootstrap.js` repeats the prefix inline because it must not import files
+it has not downloaded yet, and the shell/PowerShell installers spell it out in
+their own messages. Child process output is never rewritten into this form, exit
+codes and cause text are preserved, and there are no timestamps, log files or
+telemetry. Changing a diagnostic requires updating its assertion in
+`tests/wrapper.test.js`, `tests/bootstrap.test.js`, or `tests/smoke.test.js`.
+
 ## Verification Boundaries
 
 `test:coverage` reads real Bun LCOV output and requires at least 90% lines and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,9 @@ git diff --check
 Use `bun`, not the intercepted `npm` command, for repository development.
 ESLint and Prettier are pinned development-only dependencies. Commit `bun.lock`
 when intentionally updating tooling; never install tools during tests.
+[`.github/dependabot.yml`](.github/dependabot.yml) proposes those tooling and
+GitHub Actions updates weekly. Its pull requests are ordinary pull requests: they
+must pass the same required checks and are never merged automatically.
 
 Tests must exercise observable behavior, run offline, and clean their own fixtures.
 Use the native platform for process and installer tests; a simulated platform name

--- a/README.md
+++ b/README.md
@@ -127,10 +127,11 @@ then install again. No background updater runs.
 
 ## Architecture And Boundaries
 
-One short-lived process per invocation: no daemon, no shared state, no build
-step. A launcher in `bunpm/platforms/<os>/bin/` runs `core/wrapper.js` with the
-invoked manager name and the untouched argument list. Everything below is a
-plain CommonJS function call in that one process.
+One short-lived wrapper process per invocation: no daemon, no shared state, no
+build step. A launcher in `bunpm/platforms/<os>/bin/` runs `core/wrapper.js` with
+the invoked manager name and the untouched argument list. Everything below is a
+plain CommonJS function call in that wrapper process, which then spawns at most
+one child process: Bun, or the original manager.
 
 ```mermaid
 flowchart LR
@@ -179,12 +180,15 @@ signals become `128 + signo`.
 
 Trust boundaries: bunpm executes whatever Bun and the original managers your
 absolute PATH entries resolve to, and never validates their contents. It adds
-no registry, network access, or credentials of its own at run time; only
-`bootstrap.js` performs network I/O, restricted to this repository at one
-immutable commit SHA (see [Remote Bootstrap](#remote-bootstrap)). Installers
-write only under `~/.bunpm`, one shell profile, or Windows User PATH. bunpm's
-own failures are always `bunpm: <component>: <message>` on stderr; anything else
-on stderr came from the child.
+no registry, network access, or credentials of its own at run time.
+`bootstrap.js` is the only bunpm component that performs network I/O, restricted
+to this repository at one immutable commit SHA (see
+[Remote Bootstrap](#remote-bootstrap)); the Bun and original-manager child
+processes reach whatever registries the invoked command needs, under their own
+configuration. Installers write only under `~/.bunpm`, one shell profile, or
+Windows User PATH. bunpm's own failures are always
+`bunpm: <component>: <message>` on stderr; anything else on stderr came from the
+child.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,67 @@ lines. It leaves Bun and original package managers installed. Restart the termin
 to discard its old environment. To update, uninstall, review the new checkout,
 then install again. No background updater runs.
 
+## Architecture And Boundaries
+
+One short-lived process per invocation: no daemon, no shared state, no build
+step. A launcher in `bunpm/platforms/<os>/bin/` runs `core/wrapper.js` with the
+invoked manager name and the untouched argument list. Everything below is a
+plain CommonJS function call in that one process.
+
+```mermaid
+flowchart LR
+  L["launcher<br/>platforms/&lt;os&gt;/bin"] --> W["wrapper.js<br/>main()"]
+  W --> M["mapper.js<br/>mapCommand()"]
+  M -->|translated| B["detector.js<br/>getBunPath()"]
+  M -->|fallback| O["detector.js<br/>locateBinary()"]
+  B --> X["wrapper.js<br/>spawnCommand() / spawnSync"]
+  O --> X
+  X -->|buffered| F["formatter.js<br/>formatOutput()"]
+  X -->|interactive stdio| E["child exit code<br/>or signal"]
+  F --> E
+```
+
+- [`bunpm/core/wrapper.js`](bunpm/core/wrapper.js) — entry point: decides,
+  spawns without a shell, prints, and returns the child's exit status. Also
+  holds the `diagnose` stderr helper.
+- [`bunpm/core/mapper.js`](bunpm/core/mapper.js) — pure command/flag tables.
+  Returns either Bun arguments or a fallback instruction. No I/O.
+- [`bunpm/core/detector.js`](bunpm/core/detector.js) — resolves Bun and the
+  original managers from absolute PATH entries, skipping bunpm's own copies.
+- [`bunpm/core/formatter.js`](bunpm/core/formatter.js) — line-by-line cosmetic
+  rewrite of buffered Bun output only.
+- [`bunpm/core/platform-detect.js`](bunpm/core/platform-detect.js) — the only
+  place that maps `process.platform` to paths under `~/.bunpm`.
+
+Two components sit outside that per-command path and are used once, by hand:
+[`bunpm/bootstrap.js`](bunpm/bootstrap.js) downloads runtime files at a pinned
+revision and then hands off to an installer, and the platform installers in
+[`bunpm/platforms`](bunpm/platforms) copy files and edit PATH. Neither is
+imported by the wrapper; bootstrap deliberately imports nothing from `core/`
+because those files do not exist yet when it starts.
+
+`mapCommand` decides between two outcomes. **Translated** commands have a
+documented Bun equivalent and run through Bun, so Bun owns their lockfile and
+dependency semantics. **Fallback** commands — unknown commands or options, and
+anything whose semantics cannot be reproduced safely — run the original manager
+with the original arguments. Ambiguity always resolves to fallback rather than a
+guess, which is why the mapper is a table and not a heuristic.
+
+Fallback happens only _before_ a child mutates anything: a missing or
+non-executable binary (`ENOENT`/`EACCES`) is retried once with the original
+manager. Once Bun has started, no failure is retried, because a second manager
+could repeat a partially applied install. Exit codes pass through unchanged and
+signals become `128 + signo`.
+
+Trust boundaries: bunpm executes whatever Bun and the original managers your
+absolute PATH entries resolve to, and never validates their contents. It adds
+no registry, network access, or credentials of its own at run time; only
+`bootstrap.js` performs network I/O, restricted to this repository at one
+immutable commit SHA (see [Remote Bootstrap](#remote-bootstrap)). Installers
+write only under `~/.bunpm`, one shell profile, or Windows User PATH. bunpm's
+own failures are always `bunpm: <component>: <message>` on stderr; anything else
+on stderr came from the child.
+
 ## Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for frozen installs, offline tests,

--- a/bunpm/bootstrap.js
+++ b/bunpm/bootstrap.js
@@ -181,6 +181,8 @@ async function main(args = process.argv.slice(2)) {
 module.exports = { detectPlatform, filesFor, validateUrl, download, main };
 if (require.main === module)
   main().catch((error) => {
-    console.error(`Bootstrap error: ${error.message}`);
+    // Same `bunpm: <component>: <message>` convention as core/wrapper.js, spelled
+    // out here because bootstrap must not import files it has not downloaded yet.
+    console.error(`bunpm: bootstrap: ${error.message}`);
     process.exitCode = 1;
   });

--- a/bunpm/core/wrapper.js
+++ b/bunpm/core/wrapper.js
@@ -52,9 +52,17 @@ function spawnCommand(binary, args, options = {}) {
   return cp.spawnSync(binary, args, { ...options, shell: false });
 }
 
+// Every bunpm component reports failures on stderr as
+// `bunpm: <component>: <actionable message>` so users can tell bunpm's own
+// diagnostics apart from the child manager's output. Child exit codes and the
+// underlying cause text are preserved unchanged.
+function diagnose(component, message) {
+  console.error(`bunpm: ${component}: ${message}`);
+}
+
 function exitCode(result) {
   if (result.error) {
-    console.error(`bunpm error: ${result.error.message}`);
+    diagnose('exec', result.error.message);
     return 1;
   }
   if (result.signal) return 128 + (os.constants.signals[result.signal] || 1);
@@ -68,8 +76,9 @@ function main(invokedAs = process.argv[2], args = process.argv.slice(3)) {
     const original = () => {
       const binary = detector.locateBinary(invokedAs);
       if (!binary) {
-        console.error(
-          `bunpm error: Original ${invokedAs} not found; install it for this command or install Bun for supported commands.`,
+        diagnose(
+          'detector',
+          `original ${invokedAs} not found; install ${invokedAs} for this command, or install Bun for supported commands.`,
         );
         return 1;
       }
@@ -97,10 +106,10 @@ function main(invokedAs = process.argv[2], args = process.argv.slice(3)) {
     }
     return exitCode(result);
   } catch (error) {
-    console.error(`bunpm error: ${error.message}`);
+    diagnose('wrapper', error.message);
     return 1;
   }
 }
 
-module.exports = { main, spawnCommand, exitCode };
+module.exports = { main, spawnCommand, exitCode, diagnose };
 if (require.main === module) process.exitCode = main();

--- a/bunpm/platforms/linux/scripts/install.sh
+++ b/bunpm/platforms/linux/scripts/install.sh
@@ -7,8 +7,11 @@ INSTALL_DIR="$HOME/.bunpm"
 if [ -e "$INSTALL_DIR" ] || [ -L "$INSTALL_DIR" ]; then
   echo 'bunpm: install: existing ~/.bunpm found; run uninstall.sh before reinstalling.' >&2; exit 1
 fi
-node --version
-bun --version || { echo 'bunpm: install: Bun not found; install it from https://bun.sh first.' >&2; exit 1; }
+# Suppress the shell's own "command not found" so a missing prerequisite is
+# reported once, by us. Without the redirection and the || branch, set -e also
+# aborted on a missing node before any bunpm diagnostic was printed.
+node --version 2>/dev/null || { echo 'bunpm: install: node not found; install Node.js before running bunpm setup.' >&2; exit 1; }
+bun --version 2>/dev/null || { echo 'bunpm: install: bun not found; install it from https://bun.sh first.' >&2; exit 1; }
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_ROOT="$(dirname "$SCRIPT_DIR")"
 CORE_ROOT="$SOURCE_ROOT"

--- a/bunpm/platforms/linux/scripts/install.sh
+++ b/bunpm/platforms/linux/scripts/install.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "$#" -gt 1 ] || { [ "$#" -eq 1 ] && [ "$1" != '--no-path' ]; }; then
-  echo 'Usage: install.sh [--no-path]' >&2; exit 1
+  echo 'bunpm: install: usage: install.sh [--no-path]' >&2; exit 1
 fi
 INSTALL_DIR="$HOME/.bunpm"
 if [ -e "$INSTALL_DIR" ] || [ -L "$INSTALL_DIR" ]; then
-  echo 'bunpm already exists; uninstall before reinstalling.' >&2; exit 1
+  echo 'bunpm: install: existing ~/.bunpm found; run uninstall.sh before reinstalling.' >&2; exit 1
 fi
 node --version
-bun --version || { echo 'Install Bun separately from https://bun.sh first.' >&2; exit 1; }
+bun --version || { echo 'bunpm: install: Bun not found; install it from https://bun.sh first.' >&2; exit 1; }
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_ROOT="$(dirname "$SCRIPT_DIR")"
 CORE_ROOT="$SOURCE_ROOT"

--- a/bunpm/platforms/linux/scripts/uninstall.sh
+++ b/bunpm/platforms/linux/scripts/uninstall.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "$#" -gt 1 ] || { [ "$#" -eq 1 ] && [ "$1" != '--no-path' ]; }; then
-  echo 'Usage: uninstall.sh [--no-path]' >&2; exit 1
+  echo 'bunpm: uninstall: usage: uninstall.sh [--no-path]' >&2; exit 1
 fi
 INSTALL_DIR="$HOME/.bunpm"
 if [ "${1:-}" != '--no-path' ]; then

--- a/bunpm/platforms/macos/scripts/install.sh
+++ b/bunpm/platforms/macos/scripts/install.sh
@@ -7,8 +7,11 @@ INSTALL_DIR="$HOME/.bunpm"
 if [ -e "$INSTALL_DIR" ] || [ -L "$INSTALL_DIR" ]; then
   echo 'bunpm: install: existing ~/.bunpm found; run uninstall.sh before reinstalling.' >&2; exit 1
 fi
-node --version
-bun --version || { echo 'bunpm: install: Bun not found; install it from https://bun.sh first.' >&2; exit 1; }
+# Suppress the shell's own "command not found" so a missing prerequisite is
+# reported once, by us. Without the redirection and the || branch, set -e also
+# aborted on a missing node before any bunpm diagnostic was printed.
+node --version 2>/dev/null || { echo 'bunpm: install: node not found; install Node.js before running bunpm setup.' >&2; exit 1; }
+bun --version 2>/dev/null || { echo 'bunpm: install: bun not found; install it from https://bun.sh first.' >&2; exit 1; }
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_ROOT="$(dirname "$SCRIPT_DIR")"
 CORE_ROOT="$SOURCE_ROOT"

--- a/bunpm/platforms/macos/scripts/install.sh
+++ b/bunpm/platforms/macos/scripts/install.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "$#" -gt 1 ] || { [ "$#" -eq 1 ] && [ "$1" != '--no-path' ]; }; then
-  echo 'Usage: install.sh [--no-path]' >&2; exit 1
+  echo 'bunpm: install: usage: install.sh [--no-path]' >&2; exit 1
 fi
 INSTALL_DIR="$HOME/.bunpm"
 if [ -e "$INSTALL_DIR" ] || [ -L "$INSTALL_DIR" ]; then
-  echo 'bunpm already exists; uninstall before reinstalling.' >&2; exit 1
+  echo 'bunpm: install: existing ~/.bunpm found; run uninstall.sh before reinstalling.' >&2; exit 1
 fi
 node --version
-bun --version || { echo 'Install Bun separately from https://bun.sh first.' >&2; exit 1; }
+bun --version || { echo 'bunpm: install: Bun not found; install it from https://bun.sh first.' >&2; exit 1; }
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_ROOT="$(dirname "$SCRIPT_DIR")"
 CORE_ROOT="$SOURCE_ROOT"

--- a/bunpm/platforms/macos/scripts/uninstall.sh
+++ b/bunpm/platforms/macos/scripts/uninstall.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "$#" -gt 1 ] || { [ "$#" -eq 1 ] && [ "$1" != '--no-path' ]; }; then
-  echo 'Usage: uninstall.sh [--no-path]' >&2; exit 1
+  echo 'bunpm: uninstall: usage: uninstall.sh [--no-path]' >&2; exit 1
 fi
 INSTALL_DIR="$HOME/.bunpm"
 if [ "${1:-}" != '--no-path' ]; then

--- a/bunpm/platforms/windows/scripts/install.ps1
+++ b/bunpm/platforms/windows/scripts/install.ps1
@@ -4,8 +4,14 @@ $installDir = Join-Path $env:USERPROFILE '.bunpm'
 $binDir = Join-Path $installDir 'bin'
 if (Test-Path -LiteralPath $installDir) { throw 'bunpm: install: existing .bunpm found; run uninstall.ps1 before reinstalling.' }
 foreach ($tool in @('node', 'bun')) {
+    # With $ErrorActionPreference = 'Stop', invoking a missing command raises
+    # CommandNotFoundException and PowerShell prints its own unprefixed error
+    # before any throw below can run. Probe for it first.
+    if (-not (Get-Command $tool -CommandType Application -ErrorAction SilentlyContinue)) {
+        throw "bunpm: install: $tool not found; install it separately before running bunpm setup."
+    }
     & $tool --version
-    if ($LASTEXITCODE -ne 0) { throw "bunpm: install: $tool not found; install it separately before running bunpm setup." }
+    if ($LASTEXITCODE -ne 0) { throw "bunpm: install: $tool --version failed with exit $LASTEXITCODE; repair your $tool installation." }
 }
 $sourceRoot = Split-Path -Parent $PSScriptRoot
 $coreRoot = $sourceRoot

--- a/bunpm/platforms/windows/scripts/install.ps1
+++ b/bunpm/platforms/windows/scripts/install.ps1
@@ -2,10 +2,10 @@ param([switch]$NoPath)
 $ErrorActionPreference = 'Stop'
 $installDir = Join-Path $env:USERPROFILE '.bunpm'
 $binDir = Join-Path $installDir 'bin'
-if (Test-Path -LiteralPath $installDir) { throw 'bunpm already exists; uninstall it before reinstalling.' }
+if (Test-Path -LiteralPath $installDir) { throw 'bunpm: install: existing .bunpm found; run uninstall.ps1 before reinstalling.' }
 foreach ($tool in @('node', 'bun')) {
     & $tool --version
-    if ($LASTEXITCODE -ne 0) { throw "$tool is required. Install it separately before running bunpm setup." }
+    if ($LASTEXITCODE -ne 0) { throw "bunpm: install: $tool not found; install it separately before running bunpm setup." }
 }
 $sourceRoot = Split-Path -Parent $PSScriptRoot
 $coreRoot = $sourceRoot
@@ -13,7 +13,7 @@ if (-not (Test-Path -LiteralPath (Join-Path $coreRoot 'core'))) {
     $coreRoot = Split-Path -Parent (Split-Path -Parent $sourceRoot)
 }
 foreach ($required in @((Join-Path $coreRoot 'core'), (Join-Path $sourceRoot 'bin'), (Join-Path $PSScriptRoot 'uninstall.ps1'))) {
-    if (-not (Test-Path -LiteralPath $required)) { throw "Missing installation source: $required" }
+    if (-not (Test-Path -LiteralPath $required)) { throw "bunpm: install: missing installation source: $required" }
 }
 try {
     New-Item -ItemType Directory -Path $installDir | Out-Null

--- a/tests/bootstrap.test.js
+++ b/tests/bootstrap.test.js
@@ -12,6 +12,7 @@ const {
   detectPlatform,
   main,
 } = require('../bunpm/bootstrap');
+const { locateBinary } = require('../bunpm/core/detector');
 const sha = 'a'.repeat(40);
 const base = `https://raw.githubusercontent.com/yv3000/bunpm/${sha}/bunpm/`;
 let server, root, get, handler;
@@ -221,4 +222,21 @@ test('bootstrap never executes incomplete files and cleans each private download
   spawn.mockImplementation(() => ({ error: new Error('spawn failed') }));
   await expect(main(['--revision', sha])).rejects.toThrow('spawn failed');
   expect(fs.readdirSync(root)).toEqual([]);
+});
+
+test('bootstrap CLI reports usage with the shared diagnostic prefix', () => {
+  // Run the documented `node bootstrap.js` entrypoint: the bun test runner
+  // colorizes console.error, which is not the production invocation.
+  const node = locateBinary('node');
+  expect(node).not.toBeNull();
+  // Argument validation fails before any request, so this stays offline.
+  const result = cp.spawnSync(node, [path.resolve('bunpm/bootstrap.js')], {
+    encoding: 'utf8',
+    timeout: 15000,
+  });
+  expect(result.status).toBe(1);
+  expect(result.stdout).toBe('');
+  expect(result.stderr.trim()).toBe(
+    'bunpm: bootstrap: Usage: node bootstrap.js --revision <40-character commit SHA>',
+  );
 });

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -188,7 +188,11 @@ test('native offline install, launcher, package script, fallback and uninstall',
       expect(
         profileContent.match(/export PATH="\$HOME\/\.bunpm\/bin:\$PATH"/g),
       ).toHaveLength(1);
-      expect(script(install, false).status).not.toBe(0);
+      const blocked = script(install, false);
+      expect(blocked.status).not.toBe(0);
+      expect(blocked.stderr.trim()).toBe(
+        'bunpm: install: existing ~/.bunpm found; run uninstall.sh before reinstalling.',
+      );
       fs.appendFileSync(
         profile,
         '# keep .bunpm/bin reference\nexport UNRELATED=ok\n',
@@ -200,7 +204,14 @@ test('native offline install, launcher, package script, fallback and uninstall',
       expect(fs.readFileSync(profile, 'utf8')).not.toContain(
         '# Added by bunpm',
       );
-    } else expect(script(uninstall).status).toBe(0);
+    } else {
+      const blocked = script(install);
+      expect(blocked.status).not.toBe(0);
+      expect(blocked.stderr).toContain(
+        'bunpm: install: existing .bunpm found; run uninstall.ps1 before reinstalling.',
+      );
+      expect(script(uninstall).status).toBe(0);
+    }
     expect(fs.existsSync(installed)).toBe(false);
     expect(script(uninstall, windows).status).toBe(0);
   } finally {

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -30,6 +30,59 @@ test.skipIf(process.platform !== 'win32')(
   30000,
 );
 
+test('installer prerequisite failures name bunpm and install nothing', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bunpm-prereq-'));
+  const windows = process.platform === 'win32';
+  const platform = windows
+    ? 'windows'
+    : process.platform === 'darwin'
+      ? 'macos'
+      : 'linux';
+  const shell = locateBinary(windows ? 'powershell' : 'bash');
+  expect(shell).not.toBeNull();
+  try {
+    const home = path.join(root, 'home');
+    fs.mkdirSync(home);
+    // An empty PATH resolves neither node nor bun. The installers must report
+    // that themselves instead of letting the shell print its own diagnostic.
+    const env = { ...process.env, HOME: home, USERPROFILE: home, PATH: '' };
+    for (const key of Object.keys(env)) {
+      if (
+        ['PATH', 'HOME', 'USERPROFILE'].includes(key.toUpperCase()) &&
+        key !== key.toUpperCase()
+      )
+        delete env[key];
+    }
+    const install = path.resolve(
+      `bunpm/platforms/${platform}/scripts/install.${windows ? 'ps1' : 'sh'}`,
+    );
+    const result = cp.spawnSync(
+      shell,
+      windows
+        ? [
+            '-NoProfile',
+            '-ExecutionPolicy',
+            'Bypass',
+            '-File',
+            install,
+            '-NoPath',
+          ]
+        : [install, '--no-path'],
+      { cwd: root, env, encoding: 'utf8', timeout: 15000 },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      windows
+        ? 'bunpm: install: node not found; install it separately before running bunpm setup.'
+        : 'bunpm: install: node not found; install Node.js before running bunpm setup.',
+    );
+    // Nothing may be created before the prerequisites are satisfied.
+    expect(fs.existsSync(path.join(home, '.bunpm'))).toBe(false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}, 30000);
+
 test('native offline install, launcher, package script, fallback and uninstall', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bunpm-smoke-'));
   const windows = process.platform === 'win32';

--- a/tests/wrapper.test.js
+++ b/tests/wrapper.test.js
@@ -15,7 +15,11 @@ const {
 } = require('../bunpm/core/mapper');
 const mocks = [];
 const dirs = [];
-const savedEnv = { ...process.env };
+// Read PATH through process.env, which is case-insensitive on Windows. A
+// { ...process.env } snapshot keeps Windows' literal `Path` key, so `.PATH`
+// would be undefined and restoring it would set PATH to the string "undefined"
+// for every later test in this process.
+const savedPath = process.env.PATH;
 function mock(object, key, implementation) {
   const spy = spyOn(object, key).mockImplementation(implementation);
   mocks.push(spy);
@@ -28,7 +32,7 @@ function fixture() {
 }
 afterEach(() => {
   for (const spy of mocks.splice(0)) spy.mockRestore();
-  process.env.PATH = savedEnv.PATH;
+  process.env.PATH = savedPath;
   for (const dir of dirs.splice(0))
     fs.rmSync(dir, { recursive: true, force: true });
 });

--- a/tests/wrapper.test.js
+++ b/tests/wrapper.test.js
@@ -217,6 +217,25 @@ test('missing Bun falls back and pre-execution permission failure retries exactl
   expect(spawn).toHaveBeenCalledTimes(3);
 });
 
+test('diagnostics use one bunpm: <component>: <message> stderr convention', () => {
+  const lines = [];
+  mock(console, 'error', (line) => lines.push(line));
+  mock(detector, 'getBunPath', () => null);
+  mock(detector, 'locateBinary', () => null);
+  // A missing original manager must name the component and stay nonzero.
+  expect(main('npm', ['install'])).toBe(1);
+  // Unsupported invocations surface through the top-level wrapper handler.
+  expect(main('bad', [])).toBe(1);
+  // Pre-execution spawn failures keep the underlying cause text verbatim.
+  expect(exitCode({ error: new Error('spawn EPERM') })).toBe(1);
+  expect(lines).toEqual([
+    'bunpm: detector: original npm not found; install npm for this command, or install Bun for supported commands.',
+    'bunpm: wrapper: Expected one of: npm, npx, yarn, pnpm',
+    'bunpm: exec: spawn EPERM',
+  ]);
+  for (const line of lines) expect(line).toMatch(/^bunpm: [a-z]+: \S/);
+});
+
 test('native child argv preserves metacharacters and exact nonzero exit', () => {
   const args = [
     'space here',


### PR DESCRIPTION
Follow-up quality work after PR #11. Independently reviewable commits; no runtime dependencies, no new abstractions, no classes or frameworks.

## Changes

**`fix:` one stderr diagnostic convention** — `core/wrapper.js` said `bunpm error:`, `bootstrap.js` said `Bootstrap error:`, and the shell/PowerShell installers printed unprefixed messages, so users could not separate bunpm's own failures from the wrapped manager's output. All components now emit `bunpm: <component>: <actionable message>`. Exit codes and signal handling are unchanged; no timestamps, log files or telemetry. `bootstrap.js` repeats the prefix inline because it must not import files it has not downloaded yet. Tests assert the exact text for the `wrapper`, `detector` and `exec` components, the bootstrap CLI usage path via the documented `node bootstrap.js` entrypoint, and the native duplicate-install refusal on both Unix and Windows.

**`fix:` prerequisite failures too** — review found three paths that still bypassed the convention. On Unix, `node --version` had no `||` branch, so under `set -e` a missing node aborted with only bash's own `command not found`; a missing bun printed bash's message *and* the prefixed one. On Windows, `$ErrorActionPreference = 'Stop'` turned a missing command into a terminating `CommandNotFoundException` before the prefixed `throw` could run. Both now detect the missing tool first and report it themselves.

**`docs:` architecture and boundaries** — one new README section: a Mermaid flow from launcher through wrapper, mapper, detector, process execution and formatter; direct links to each source file; the translated-versus-fallback rule; the no-retry-after-mutation rule; and the run-time trust boundaries.

**`chore:` weekly dependency maintenance** — new `.github/dependabot.yml`, no auto-merge, so every proposal is an ordinary PR subject to the same required checks. Uses the **`bun`** ecosystem rather than `npm`: this repository commits the text-based `bun.lock` and CI installs with `--frozen-lockfile`, and the `npm` ecosystem does not maintain `bun.lock`, so a manifest-only bump would fail every job.

**`test:` PATH restore isolation fix** — root cause found by `test:repeat`, not a workaround. `wrapper.test.js` snapshotted the environment with `{ ...process.env }`, whose Windows key is literally `Path`; reading `.PATH` returned `undefined`, and assigning that back stored the string `"undefined"`, destroying PATH for every later test in the process. The default file order hid it; seed 20260909 exposed it.

## Verification

Fresh disposable clone of `main` (README instructions only, Node 22.22.2 / Bun 1.3.14, no reuse of existing `node_modules`): `bun install --frozen-lockfile --ignore-scripts` installed 78 packages, then `bun test`, `lint`, `format:check` and `syntax:check` all exited 0. `bun.lock` is tracked and frozen-install compatible, so the scanner claims of "no runnable test suite" and "no committed lockfile" do not hold against this repository.

Full local sequence on this branch, all exit 0: frozen install, `test` (26 pass / 0 fail, up from 23), `test:coverage`, `test:repeat` (all three seeds), `lint`, `format:check`, `syntax:check`, `audit` (no vulnerabilities), `smoke`, `shell:check`, `git diff --check`. Coverage gate: `wrapper.js`, `mapper.js`, `detector.js` and `platform-detect.js` at 100% lines and functions, `formatter.js` 97.65/100, `bootstrap.js` 97.63/92.86 — all above the 90% per-file threshold. PowerShell parsed all three installers with 0 errors. `.github/dependabot.yml` parses as YAML and passes Prettier.

Not run locally: `bash -n` (this Windows host has no WSL distro; the installers were instead executed directly under Git bash 5) and `actionlint` (not installed, and no workflow file changed on this branch). Both run in CI on Linux.

## Deliberately not done

The coverage gate was not moved to Ubuntu. `wrapper.js`'s Windows batch-spawn branches cannot execute on Linux, so a per-file 90% gate would fail there; the gate already runs once per PR on Windows, which is where those branches are reachable, and `CONTRIBUTING.md` documents that reasoning. No release, tag, or version bump is included.